### PR TITLE
Fix/hide about sidemenu

### DIFF
--- a/app/components/Hero/index.tsx
+++ b/app/components/Hero/index.tsx
@@ -311,7 +311,7 @@ export default function BaseGlobe() {
         >
           <div className=" flex h-full w-full justify-center flex-col text-white items-center">
             <div className="flex flex-col mt-10 mobile:mt-5 items-center justify-center h-full gap-5 tablet:gap-[120px]">
-              <div className="flex w-full max-w-full tablet:max-w-[1000px] flex-col items-start justify-start gap-5 text-xl font-thin text-white">
+              <div className="flex w-full max-w-full tablet:max-w-[1000px] flex-col items-start justify-start gap-2 lg:gap-5 text-xl font-thin text-white">
                 <div className="text-xl tablet:text-5xl font-semibold whitespace-nowrap">{`BASE\nIS FOR EVERYONE`}</div>
                 <div className="text-sm leading-tight tablet:text-xl">
                   Base is paving the way for the next generation of the
@@ -330,7 +330,7 @@ export default function BaseGlobe() {
                   vision of Base and the Global Onchain Economy.`}
                 </div>
               </div>
-              <div className="flex w-full tablet:max-w-[1000px] flex-col items-start justify-start gap-5 text-xl font-thin text-white">
+              <div className="flex w-full tablet:max-w-[1000px] flex-col items-start justify-start gap-2 lg:gap-5 text-xl font-thin text-white">
                 <div className="text-xl tablet:text-5xl font-semibold whitespace-nowrap">{`ONCHAIN SUMMER\nIS FOR EVERYONE`}</div>
                 <div className="text-sm leading-tight mobile:text-xl">
                   Onchain Summer is a global movement calling on the ecosystem

--- a/app/components/mobile-menu.tsx
+++ b/app/components/mobile-menu.tsx
@@ -68,17 +68,19 @@ const SideMenu = () => {
               >
                 <Link href="/leaderboard">Leaderboard</Link>
               </Button>
-              <Button
-                className="text-sm tablet:text-base hover:bg-white hover:text-black"
-                onClick={() => {
-                  deactivateGlobe(true);
-                  setOpen(false);
-                  useMapStore.setState({ about: true });
-                }}
-                variant="ghost"
-              >
-                About
-              </Button>
+              {pathname !== "/leaderboard" && (
+                <Button
+                  className="text-sm tablet:text-base hover:bg-white hover:text-black"
+                  onClick={() => {
+                    deactivateGlobe(true);
+                    setOpen(false);
+                    useMapStore.setState({ about: true });
+                  }}
+                  variant="ghost"
+                >
+                  About
+                </Button>
+              )}
             </div>
           </SheetDescription>
         </SheetHeader>


### PR DESCRIPTION
Hide about from /leaderboard

<img width="590" alt="image" src="https://github.com/user-attachments/assets/cacb9f4e-9aca-44e8-aa3d-fc9e1ef93aa5">

<img width="590" alt="image" src="https://github.com/user-attachments/assets/9da127b6-677e-4552-b239-ade8bb64ddea">

Adjust gap sizing for mobile text on about  

<img width="590" alt="image" src="https://github.com/user-attachments/assets/ecfa1bd3-bf7e-4fb3-8c85-fdbc3ab68bf0">
