### PR TITLE
fix(about): set backdropFilter for text readablity about section based on feedback

### DIFF
--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -297,7 +297,7 @@ export default function BaseGlobe() {
           animate={{
             opacity: about ? 1 : 0,
             pointerEvents: about ? "auto" : "none",
-            backdropFilter: about ? `blur(300px)` : `blur(0px)`,
+            backdropFilter: about && isMobile() ? `blur(300px)` : `blur(20px)`,
             transition: {
               backdropFilter: { delay: about ? 1 : 0 },
               opacity: {

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -298,7 +298,7 @@ export default function BaseGlobe() {
           animate={{
             opacity: about ? 1 : 0,
             pointerEvents: about ? "auto" : "none",
-            backdropFilter: about ? `blur(4px)` : `blur(0px)`,
+            backdropFilter: about ? `blur(300px)` : `blur(0px)`,
             transition: {
               backdropFilter: { delay: about ? 1 : 0 },
               opacity: {


### PR DESCRIPTION

This is a temp fix. There are cases where the globe zooms out because of the globe's interaction logic like on the second pic. Will need to be treated later.

<img width="428" alt="Screenshot 2567-07-28 at 22 44 57" src="https://github.com/user-attachments/assets/081fe854-4293-4812-9515-228b1e465474">

<img width="428" alt="Screenshot 2567-07-28 at 22 58 39" src="https://github.com/user-attachments/assets/02f0af87-0e4a-4460-a78b-e0c8b07a999d"> 



